### PR TITLE
CI: build with trunk and publish dist/ to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: build & deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same ref so we don't deploy out-of-order.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write   # peaceiris/actions-gh-pages needs to push to gh-pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install rust toolchain (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: install trunk (prebuilt binary)
+        run: |
+          curl -fL https://github.com/trunk-rs/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C "$HOME/.cargo/bin"
+          trunk --version
+
+      - name: build
+        # `--public-url /tasa-hertsi/` makes assets resolve correctly when
+        # served from the project's GitHub Pages URL
+        # (https://<user>.github.io/tasa-hertsi/). Drop it for a custom
+        # domain or for serving at the root.
+        run: trunk build --release --public-url /tasa-hertsi/
+
+      - name: deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true   # keep the gh-pages branch lean (no history)


### PR DESCRIPTION
## Summary
Adds [.github/workflows/deploy.yml](.github/workflows/deploy.yml). On push to `main` (or via manual `workflow_dispatch`):

1. Sets up `rust-toolchain@stable` with the `wasm32-unknown-unknown` target
2. Caches `~/.cargo/registry`, `~/.cargo/git`, and `target/` keyed on `Cargo.lock`
3. Drops a prebuilt `trunk` binary from the [trunk-rs releases](https://github.com/trunk-rs/trunk/releases) into `~/.cargo/bin` (much faster than `cargo install trunk` from source)
4. `trunk build --release --public-url /tasa-hertsi/`
5. Pushes the `dist/` directory to the `gh-pages` branch via [`peaceiris/actions-gh-pages@v4`](https://github.com/peaceiris/actions-gh-pages) with `force_orphan: true` so the deploy branch never grows old history

`concurrency` is set so an in-flight deploy is cancelled if a newer commit lands on `main`.

After this merges, **enable Pages** in the repo settings (*Settings → Pages → Source: Deploy from a branch → `gh-pages` / `/ (root)`*) — the workflow creates the branch on first run but doesn't toggle Pages itself.

## Notes / things to tweak
- `--public-url /tasa-hertsi/` is hard-coded for the project page URL (`https://janianttonen.github.io/tasa-hertsi/`). Drop the flag (or change it) if you set up a custom domain or move the repo
- If you want PR previews built too, change the trigger to also include `pull_request` — but that won't deploy, just build, so you'd want to gate the deploy step on `github.event_name == 'push'`

## Test plan
- [ ] After merge, watch the workflow run on `main` → finishes green
- [ ] `gh-pages` branch exists with `index.html`, `*.wasm`, `*.js`
- [ ] Pages enabled → `https://janianttonen.github.io/tasa-hertsi/` loads the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)