### PR TITLE
CI: add fmt + clippy gate, resolve all clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: fmt + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install rust toolchain (stable, with rustfmt + clippy + wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-lint-
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy (deny warnings)
+        run: cargo clippy --target wasm32-unknown-unknown --lib --all-features -- -D warnings

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use leptos::html::Canvas;
 use leptos::*;
+use wasm_bindgen::JsCast;
 use web_sys::HtmlCanvasElement;
 
 use crate::audio::{Audio, SourceKind};
@@ -88,7 +89,20 @@ pub fn App() -> impl IntoView {
             } else {
                 let audio = audio.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    let _ = audio.borrow_mut().start_mic().await;
+                    // Two-step so the RefCell isn't held across the .await.
+                    let promise = match audio.borrow_mut().begin_mic_request() {
+                        Ok(p) => p,
+                        Err(_) => return,
+                    };
+                    let stream_js = match wasm_bindgen_futures::JsFuture::from(promise).await {
+                        Ok(v) => v,
+                        Err(_) => return,
+                    };
+                    let stream = match stream_js.dyn_into::<web_sys::MediaStream>() {
+                        Ok(s) => s,
+                        Err(_) => return,
+                    };
+                    let _ = audio.borrow_mut().attach_mic_stream(stream);
                 });
             }
         }
@@ -113,10 +127,8 @@ pub fn App() -> impl IntoView {
     let output_gain = create_memo(move |_| params.with(|p| p.output_gain));
 
     // Setters for each parameter.
-    let set_shift_hz =
-        move |v: f32| set_params.update(|p| p.ssb.shift_hz = v);
-    let set_stereo_spread =
-        move |v: f32| set_params.update(|p| p.ssb.stereo_spread_hz = v);
+    let set_shift_hz = move |v: f32| set_params.update(|p| p.ssb.shift_hz = v);
+    let set_stereo_spread = move |v: f32| set_params.update(|p| p.ssb.stereo_spread_hz = v);
     let set_upper_sb = move |v: f32| set_params.update(|p| p.ssb.upper_level = v);
     let set_lower_sb = move |v: f32| set_params.update(|p| p.ssb.lower_level = v);
     let set_feedback = move |v: f32| set_params.update(|p| p.ssb.feedback = v);
@@ -132,17 +144,17 @@ pub fn App() -> impl IntoView {
     let is_file_playing = create_memo(move |_| source.get() == SourceKind::File);
     let is_mic_active = create_memo(move |_| source.get() == SourceKind::Mic);
 
-    let file_name_view = move || {
-        match loaded_name.get() {
-            Some(n) => view! {
-                <span class="file-name">
-                    {format!("{} · {:.1}s", truncate(&n, 28), 0.0_f32)}
-                </span>
-            }.into_view(),
-            None => view! {
-                <span class="file-name"><span class="empty">"no file loaded"</span></span>
-            }.into_view(),
+    let file_name_view = move || match loaded_name.get() {
+        Some(n) => view! {
+            <span class="file-name">
+                {format!("{} · {:.1}s", truncate(&n, 28), 0.0_f32)}
+            </span>
         }
+        .into_view(),
+        None => view! {
+            <span class="file-name"><span class="empty">"no file loaded"</span></span>
+        }
+        .into_view(),
     };
 
     let peak_pct = move || (peak.get().clamp(0.0, 1.5) / 1.5 * 100.0) as f64;
@@ -285,6 +297,9 @@ pub fn App() -> impl IntoView {
     }
 }
 
+// slider_row is a thin view helper; bundling these into a struct would just
+// add ceremony for one call site each.
+#[allow(clippy::too_many_arguments)]
 fn slider_row(
     label: &'static str,
     value: Signal<f32>,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -189,7 +189,10 @@ impl Audio {
         Ok(())
     }
 
-    pub async fn start_mic(&mut self) -> Result<(), JsValue> {
+    /// Stop any current source, resume the AudioContext, and kick off a
+    /// `getUserMedia` request. Returns the JS Promise so the caller can
+    /// `.await` it without holding a `RefCell` borrow.
+    pub fn begin_mic_request(&mut self) -> Result<js_sys::Promise, JsValue> {
         self.stop();
         self.resume();
         let nav = web_sys::window().ok_or("no window")?.navigator();
@@ -197,13 +200,13 @@ impl Audio {
         let constraints = MediaStreamConstraints::new();
         constraints.set_audio(&JsValue::TRUE);
         constraints.set_video(&JsValue::FALSE);
-        let promise = media.get_user_media_with_constraints(&constraints)?;
-        let stream_js = JsFuture::from(promise).await?;
-        let stream: MediaStream = stream_js.dyn_into()?;
+        media.get_user_media_with_constraints(&constraints)
+    }
 
+    /// Plug the resolved `MediaStream` into the audio graph.
+    pub fn attach_mic_stream(&mut self, stream: MediaStream) -> Result<(), JsValue> {
         let src = self.ctx.create_media_stream_source(&stream)?;
         src.connect_with_audio_node(&self.script)?;
-
         self.mic_source = Some(src);
         self.mic_stream = Some(stream);
         let mut st = self.status.borrow_mut();
@@ -214,6 +217,10 @@ impl Audio {
 
     pub fn stop(&mut self) {
         if let Some(src) = self.file_source.take() {
+            // web-sys flagged `stop()` deprecated in 0.3.95 in favour of the
+            // typed `stop_with_when(...)`, but the no-arg variant is still
+            // the spec-canonical way to stop "now".
+            #[allow(deprecated)]
             let _ = src.stop();
             let _ = src.disconnect();
         }

--- a/src/dsp/engine.rs
+++ b/src/dsp/engine.rs
@@ -99,11 +99,7 @@ impl Engine {
             *s *= g;
             // Final safety clip — keeps a runaway feedback bomb out of the
             // user's speakers without affecting normal level material.
-            if *s > 1.0 {
-                *s = 1.0;
-            } else if *s < -1.0 {
-                *s = -1.0;
-            }
+            *s = s.clamp(-1.0, 1.0);
         }
     }
 }

--- a/src/dsp/hilbert.rs
+++ b/src/dsp/hilbert.rs
@@ -18,7 +18,7 @@ impl HilbertFir {
         assert!(n_taps % 2 == 1, "Hilbert FIR length must be odd");
         let m = (n_taps - 1) / 2;
         let mut taps = vec![0.0f32; n_taps];
-        for k in 0..n_taps {
+        for (k, tap) in taps.iter_mut().enumerate() {
             let i = k as i32 - m as i32;
             let h = if i == 0 || i % 2 == 0 {
                 0.0
@@ -27,7 +27,7 @@ impl HilbertFir {
             };
             // Hann window to keep the impulse response well-behaved on truncation.
             let w = 0.5 - 0.5 * (2.0 * PI * k as f32 / (n_taps - 1) as f32).cos();
-            taps[k] = h * w;
+            *tap = h * w;
         }
         Self {
             taps,

--- a/src/dsp/mod.rs
+++ b/src/dsp/mod.rs
@@ -1,6 +1,6 @@
-pub mod hilbert;
-pub mod ssb;
-pub mod spectral;
 pub mod engine;
+pub mod hilbert;
+pub mod spectral;
+pub mod ssb;
 
 pub use engine::{Engine, EngineMode, Params};

--- a/src/dsp/spectral.rs
+++ b/src/dsp/spectral.rs
@@ -1,3 +1,7 @@
+// Several inner loops index into multiple parallel arrays (input ring +
+// window + FFT scratch + output ring); the range-loop form is the most
+// readable shape for that, so suppress the lint for this whole module.
+#![allow(clippy::needless_range_loop)]
 use std::f32::consts::{PI, TAU};
 use std::sync::Arc;
 

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -1,8 +1,7 @@
 //! Canvas2D drawing for the live output spectrum (monochrome, no glow).
 //!
-//! Bars are drawn with a vertical white→dark-gray gradient: that gives
-//! depth without adding any color or shadowBlur. Cutoff line and shift
-//! arrows are crisp white strokes.
+//! Bars are flat white on flat black. Active band is a low-alpha white
+//! wash. Cutoff line and shift arrows are crisp white strokes.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -78,10 +77,10 @@ fn request_animation_frame(closure: &Closure<dyn FnMut()>) {
 }
 
 fn set_fill(ctx: &CanvasRenderingContext2d, color: &str) {
-    ctx.set_fill_style(&JsValue::from_str(color));
+    ctx.set_fill_style_str(color);
 }
 fn set_stroke(ctx: &CanvasRenderingContext2d, color: &str) {
-    ctx.set_stroke_style(&JsValue::from_str(color));
+    ctx.set_stroke_style_str(color);
 }
 
 fn draw(
@@ -196,13 +195,13 @@ fn draw(
         } else {
             -6.0
         };
-        let _ = ctx.set_text_align(if dir > 0.0 { "left" } else { "right" });
+        ctx.set_text_align(if dir > 0.0 { "left" } else { "right" });
         let _ = ctx.fill_text(
             &format!("cutoff {} {:.0} Hz", arrow, p.spec.cutoff_hz),
             cx + dir,
             inner_y + 16.0,
         );
-        let _ = ctx.set_text_align("left");
+        ctx.set_text_align("left");
     }
 
     // Shift indicator: arrows at 100 Hz / 1 kHz / 10 kHz, white.
@@ -245,7 +244,7 @@ fn draw(
         // Centered shift label
         let center_x = (f_to_x(active_lo.max(f_min)) + f_to_x(active_hi.min(f_max))) * 0.5;
         ctx.set_font("11px ui-sans-serif, system-ui, sans-serif");
-        let _ = ctx.set_text_align("center");
+        ctx.set_text_align("center");
         set_fill(ctx, "#ffffff");
         let sign = if shift_hz > 0.0 { "+" } else { "" };
         let _ = ctx.fill_text(
@@ -253,6 +252,6 @@ fn draw(
             center_x,
             inner_y + 16.0,
         );
-        let _ = ctx.set_text_align("left");
+        ctx.set_text_align("left");
     }
 }


### PR DESCRIPTION
## Summary
- Adds **[.github/workflows/ci.yml](.github/workflows/ci.yml)** — runs on every push and pull_request:
  - `cargo fmt --all -- --check`
  - `cargo clippy --target wasm32-unknown-unknown --lib --all-features -- -D warnings`
- Pair this with a branch-protection rule on `main` requiring **fmt + clippy** to pass before merge — that's what makes it a CI *requirement*, since `--required` lives in repo settings, not in the workflow YAML.

## Code fixes (clippy was angry at 14 things)
- `src/dsp/hilbert.rs` — `enumerate()` over `taps` instead of indexing through a range
- `src/dsp/engine.rs` — `s.clamp(-1.0, 1.0)` instead of a manual `if`/`else`
- `src/dsp/spectral.rs` — `#![allow(clippy::needless_range_loop)]` at module scope; the inner loops index in lockstep across input ring + window + FFT scratch + output ring, and the range form is the readable shape for that
- `src/spectrum.rs` — switched to `set_fill_style_str` / `set_stroke_style_str` (the non-deprecated typed setters in web-sys 0.3.95+); dropped pointless `let _ = ` on `set_text_align(...)` (returns `()`)
- `src/audio.rs` — split `start_mic` into `begin_mic_request` (sync) + `attach_mic_stream` (sync) so the caller's `RefCell` borrow doesn't span an `.await` (clippy::await_holding_refcell_ref). One remaining intentionally-deprecated call (`AudioBufferSourceNode::stop`) carries `#[allow(deprecated)]` with an explanation
- `src/app.rs` — uses the new two-step mic API; `#[allow(clippy::too_many_arguments)]` on the `slider_row` view helper (bundling 9 args into a struct would just add ceremony for one call site each)
- `cargo fmt` across the tree

## Test plan
- [ ] Workflow runs on this PR and passes `fmt + clippy`
- [ ] Locally: `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` is clean
- [ ] Locally: `cargo fmt --all -- --check` is clean
- [ ] After merge, set Settings → Branches → Protect `main` → require **fmt + clippy** check before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)