### PR TITLE
Make slider value boxes editable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -328,15 +328,9 @@ fn slider_row(
         }
     };
     let class = if bipolar { "slider bipolar" } else { "slider" };
-    let val_text = move || {
-        let v = value.get();
-        match decimals {
-            0 => format!("{:.0}{}", v, suffix),
-            1 => format!("{:.1}{}", v, suffix),
-            2 => format!("{:.2}{}", v, suffix),
-            _ => format!("{:.3}{}", v, suffix),
-        }
-    };
+    let val_input_text = move || fmt_value(value.get(), decimals);
+    let suffix_trimmed = suffix.trim();
+    let has_suffix = !suffix_trimmed.is_empty();
 
     view! {
         <div class="slider-row">
@@ -354,8 +348,58 @@ fn slider_row(
                     on_input(v);
                 }
             />
-            <div class="val">{val_text}</div>
+            <div class="val">
+                <input
+                    type="number"
+                    class="val-input"
+                    min=min.to_string()
+                    max=max.to_string()
+                    step=step.to_string()
+                    prop:value=val_input_text
+                    on:change=move |ev| {
+                        let target = match ev.target()
+                            .and_then(|t| t.dyn_into::<web_sys::HtmlInputElement>().ok()) {
+                            Some(t) => t,
+                            None => return,
+                        };
+                        let raw = target.value();
+                        match raw.trim().parse::<f32>() {
+                            Ok(v) => {
+                                let clamped = v.clamp(min, max);
+                                on_input(clamped);
+                                // Force the displayed value to reflect the
+                                // clamped/parsed result (signal write may
+                                // be a no-op if unchanged, in which case
+                                // prop:value won't fire on its own).
+                                target.set_value(&fmt_value(clamped, decimals));
+                            }
+                            Err(_) => {
+                                target.set_value(&fmt_value(value.get(), decimals));
+                            }
+                        }
+                    }
+                    on:keydown=move |ev| {
+                        if ev.key() == "Enter" {
+                            if let Some(t) = ev.target()
+                                .and_then(|t| t.dyn_into::<web_sys::HtmlInputElement>().ok())
+                            {
+                                let _ = t.blur();
+                            }
+                        }
+                    }
+                />
+                {has_suffix.then(|| view! { <span class="val-suffix">{suffix_trimmed}</span> })}
+            </div>
         </div>
+    }
+}
+
+fn fmt_value(v: f32, decimals: u8) -> String {
+    match decimals {
+        0 => format!("{:.0}", v),
+        1 => format!("{:.1}", v),
+        2 => format!("{:.2}", v),
+        _ => format!("{:.3}", v),
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -218,21 +218,52 @@ html, body {
 /* ----- slider rows (flat) ----- */
 .slider-row {
   display: grid;
-  grid-template-columns: 110px 1fr 64px;
+  grid-template-columns: 110px 1fr 84px;
   align-items: center;
   gap: 14px;
   padding: 5px 0;
 }
 .slider-row > .label { font-size: 12px; color: var(--text-dim); text-align: right; }
+
+/* the .val cell is now an inline editable number input + optional suffix */
 .slider-row > .val {
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  height: 22px;
   background: #000;
   border: 1px solid var(--panel-edge);
-  padding: 3px 8px;
+  padding: 1px 6px;
   border-radius: 4px;
+  transition: border-color 0.12s ease;
+}
+.slider-row > .val:focus-within { border-color: var(--panel-edge-bright); }
+
+.val-input {
+  font: inherit;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  text-align: right;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.val-input::-webkit-outer-spin-button,
+.val-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.val-suffix {
+  font-size: 10px;
+  color: var(--text-mute);
+  flex-shrink: 0;
 }
 
 input[type="range"].slider {
@@ -297,6 +328,6 @@ input[type="range"].slider::-moz-range-thumb {
 
 /* ----- responsive ----- */
 @media (max-width: 720px) {
-  .slider-row { grid-template-columns: 90px 1fr 56px; gap: 10px; }
+  .slider-row { grid-template-columns: 90px 1fr 76px; gap: 10px; }
   .app { padding: 12px; }
 }


### PR DESCRIPTION
## Summary
Each slider row's right-hand "val" cell is now an `<input type="number">`. Click in, type a precise value, press Enter or click out — the parameter signal updates and the slider snaps to match.

- Commits on `change` (blur or Enter — the keydown handler synthesises a blur on Enter so you don't have to tab away)
- Clamps the parsed value to `[min, max]`
- On parse failure, the input snaps back to the current signal value
- Force-updates the input's text after a `change` so a clamped/unchanged signal write doesn't leave stale typed text
- Suffix (e.g. `Hz`) moved into a small dim sibling span; native number-input spinners hidden
- Value column widened 64 → 84 px (76 px on small screens) to fit `+2000 Hz`-class values + suffix

## Test plan
- [ ] Type `750` in the SSB shift box → slider jumps to +750 Hz
- [ ] Type `99999` → clamps to `2000`
- [ ] Type `abc` → snaps back to current value
- [ ] Press Enter while typing → commits without needing to click out
- [ ] Locale with comma decimal (e.g. fi-FI) renders `1,000` for 1.0 but parsing still works
- [ ] Drag slider → value box updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)